### PR TITLE
Example from the documentation is failing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ rightscale_volume "db_data_volume" do
 end
 
 execute "format volume as ext4" do
-  command "mkfs.ext4 #{node['rightscale_volume']['db_data_volume']['device']}"
+  command lazy { "mkfs.ext4 #{node['rightscale_volume']['db_data_volume']['device']}" }
   action :run
 end
 
 execute "mount volume to /mnt/storage" do
-  command "mkdir -p /mnt/storage; mount #{node['rightscale_volume']['db_data_volume']['device']} /mnt/storage"
+  command lazy { "mkdir -p /mnt/storage; mount #{node['rightscale_volume']['db_data_volume']['device']} /mnt/storage" }
   action :run
 end
 ```


### PR DESCRIPTION
I tried to use your cookbook to create a ebs volume for my rightscale server, copied an example you have and got the following error:

```
NoMethodError[0m
-------------[0m
undefined method `[]' for nil:NilClass[0m

[0m
Cookbook Trace:[0m
---------------[0m
  /var/chef/cache/cookbooks/edufii/recipes/ebs.rb:16:in `block in from_file'
  /var/chef/cache/cookbooks/edufii/recipes/ebs.rb:15:in `from_file'[0m

[0m
Relevant File Content:[0m
----------------------[0m
/var/chef/cache/cookbooks/edufii/recipes/ebs.rb:

  9:  
 10:    # Attaches the volume to the instance
 11:    rightscale_volume "db_data_volume" do
 12:      action :attach
 13:    end
 14:  
 15:    execute "format volume as ext4" do
 16>>     command "mkfs.ext4 #{node['rightscale_volume']['db_data_volume']['device']}"
 17:      action :run
 18:    end
 19:  
 20:    execute "mount volume to /mnt/ebs" do
 21:      command "mkdir -p /mnt/ebs; mount #{node['rightscale_volume']['db_data_volume']['device']} /mnt/ebs"
 22:      action :run
 23:    end
 24:  end
 25:  [0m

[0m
18:07:29: Script duration: 12.876087
*ERROR> 18:07:29: execute[run chef client] (chef::do_client_converge line 35) has had an error
```

Can you please advice, do I need to have some attributes configured in order to run this example?
