### PR TITLE
Add support for gce cloud provider

### DIFF
--- a/libraries/provider_rightscale_volume.rb
+++ b/libraries/provider_rightscale_volume.rb
@@ -475,7 +475,7 @@ class Chef
 
         # use the lowest available LUN if we are on Azure/HyperV/VirtualPC
         hypervisor = node[:virtualization][:system] || node[:virtualization][:emulator]
-        if hypervisor == "virtualpc" || node['cloud']['provider'] == "google"
+        if hypervisor == "virtualpc" || ['gce', 'google'].include?(node['cloud']['provider'])
           luns = attached_devices.map { |attached_device| attached_device.to_i }.to_set
           lun = 0
           params[:volume_attachment][:device] = loop do


### PR DESCRIPTION
In the attach action, we [check](https://github.com/rightscale-cookbooks/rightscale_volume/blob/master/libraries/provider_rightscale_volume.rb#L478) for the cloud provider `google` but it should also include `gce`.
