### PR TITLE
Do not raise from load_current_resource

### DIFF
--- a/libraries/provider_rightscale_volume.rb
+++ b/libraries/provider_rightscale_volume.rb
@@ -46,7 +46,7 @@ class Chef
           volume = find_volumes(:resource_uid => node['rightscale_volume'][@current_resource.nickname]['volume_id']).first
           if volume.nil?
             delete_device_hash
-            raise "Volume '#{node['rightscale_volume'][@current_resource.nickname]}'" +
+            Chef::Log.info "Volume '#{node['rightscale_volume'][@current_resource.nickname]}'" +
               " could not be found in the cloud"
           else
             volume_details = volume.show

--- a/spec/unit_test/provider_rightscale_volume_spec.rb
+++ b/spec/unit_test/provider_rightscale_volume_spec.rb
@@ -164,11 +164,11 @@ describe Chef::Provider::RightscaleVolume do
       end
 
       context "when the volume does not exist in the cloud" do
-        it "should raise an exception" do
+        it "should not raise an exception" do
           provider.stub(:find_volumes).and_return([])
           expect {
             provider.load_current_resource
-          }.to raise_error(RuntimeError)
+          }.not_to raise_error(RuntimeError)
         end
       end
     end


### PR DESCRIPTION
- In order to actually be idempotent, the load_current_resource method
  which is called by all actions shouldn't raise if a volume that may
  have previously existed no longer exists.
