### PR TITLE
pin right_api_client

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,8 +2,6 @@ site :opscode
 
 metadata
 
-cookbook 'build-essential'
-
 cookbook "delayed_evaluator", github: "chrisroberts/cookbook-delayed_evaluator"
 cookbook "marker", github: "rightscale-cookbooks/marker"
 cookbook "test-rightscale_volume", path: "./test/cookbooks/test-rightscale_volume"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ rightscale_volume Cookbook CHANGELOG
 
 This file is used to list changes made in each version of the rightscale_volume cookbook.
 
+v1.3.1
+------
+- Pin right_api_client at v1.6.1 for ruby 1.9.3 support, Chef 11
+
 v1.2.10
 -------
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'berkshelf'
 gem 'thor-foodcritic'
 gem 'thor-scmversion'
 gem 'right_api_client'
-gem 'rightscale_upload', :github => 'rightscale/rightscale_upload'
 
 group :integration do
   gem 'strainer', '~> 3.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,8 @@ group :integration do
   gem 'rspec', '~> 2.14.1'
   gem 'ohai', '~> 7.4.0'
   gem 'travis-lint'
+  gem 'buff-ignore','1.1.1'
+  gem 'rack', '1.6.4'
+  gem 'json','~> 1.8.0'
+  gem 'net-http-persistent', '= 2.9.4'
 end

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Github Repository: [https://github.com/rightscale-cookbooks/rightscale_volume](h
 # Requirements
 
 * The system being configured must be a RightScale managed VM to have the required access to the RightScale API.
-* Chef 11 or higher.
+* Chef 11.
 * [RightLink 10](http://docs.rightscale.com/rl10/) See cookbook version 1.2.6 for RightLink 6 support
 * Also requires a RightScale account that is registered with all the cloud vendors
   you expect to provision on (e.g. AWS, Rackspace, Openstack, CloudStack, GCE, and Azure).

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Provides a resource to manage volumes on any cloud RightScale supports.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.3.0'
+version          '1.3.1'
 
-depends 'build-essential'
+depends 'build-essential', '3.2.0'
 recipe "rightscale_volume::default", "Default recipe for installing required packages/gems."

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,4 +25,7 @@ include_recipe 'build-essential'
 
 # Install gems during compile phase so that they are available to files
 # which require them during converge phase.
-chef_gem 'right_api_client'
+# pin gem for ruby 1.9/chef 11 compatiblity
+chef_gem 'right_api_client' do
+  version "1.6.1"
+end


### PR DESCRIPTION
chef 11 only supports ruby 1.9.3 and right_api_client now only support ruby => 2.0.
pinning right_api_client at 1.6.1 until chef 12 is supported.